### PR TITLE
Use correct path for docker action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # parameterizable-docker-action-example
+
+Forked from https://github.com/JavierZolotarchuk/parameterizable-docker-action-example with a little fix so this action also supports being executed outside the context of the action repository itself. 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,11 +2,11 @@
 
 ALPINE_VERSION=$1
 
-cd docker-action
+cd /docker-action
 echo "creating docker image with alpine version: $ALPINE_VERSION"
 
 # here we can make the construction of the image as customizable as we need
-# and if we need parameterizable values ​​it is a matter of sending them as inputs
+# and if we need parameterizable values it is a matter of sending them as inputs
 docker build -t docker-action --build-arg alpine_version="$ALPINE_VERSION" . && docker run docker-action
 
 


### PR DESCRIPTION
The Dockerfile in this repository copies the docker-action directory to `/docker-action`, but entrypoint.sh is using a relative path. This doesn't fail if you call this action from within the same repository ([because you checkout the repository content first](https://github.com/JavierZolotarchuk/parameterizable-docker-action-example/blob/master/.github/workflows/main.yml#L10)), but in all other cases it will cause a "directory or file not found" error. 

I updated entrypoint.sh to use an absolute path. 